### PR TITLE
Add Wizard Form

### DIFF
--- a/src/components/wizardForm/WizardFormConfirmation.js
+++ b/src/components/wizardForm/WizardFormConfirmation.js
@@ -1,0 +1,33 @@
+import React, { Fragment } from 'react';
+import Button from '../../components/buttons/Button';
+
+const NULL = 'NULL';
+
+function WizardFormConfirmation({ questions, handleAnswer, handleSubmit }) {
+  const handleChange = qIx => e => {
+    const oIx = e.target.value === NULL ? null : +e.target.value;
+    handleAnswer(qIx)(oIx)(e);
+  };
+  return (
+    <div>
+      <h2>WizardFormConfirmation</h2>
+      <p>Please review your answers before submitting</p>
+      {questions.map(({ title, options, selected }, qIx) => (
+        <Fragment key={qIx}>
+          <label htmlFor={title}>{title}</label>
+          <select onChange={handleChange(qIx)} value={selected || NULL} id={title}>
+            <option value={NULL}>Not applicable</option>
+            {options.map((opt, oIx) => (
+              <option key={oIx} value={oIx}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        </Fragment>
+      ))}
+      <Button clickEvent={handleSubmit} buttonStyle="" buttonText="Submit" />
+    </div>
+  );
+}
+
+export default WizardFormConfirmation;

--- a/src/components/wizardForm/WizardFormQA.js
+++ b/src/components/wizardForm/WizardFormQA.js
@@ -1,9 +1,21 @@
 import React from 'react';
+import Button from '../../components/buttons/Button';
 
-function WizardFormQA() {
+function WizardFormQA({ step, handleAnswer, handlePrev, handleNext, questionContent, options, selected }) {
   return (
     <div>
-      <div>WizardFormQA</div>
+      <div>{questionContent}</div>
+      {options.map((option, i) => {
+        const id = `${option}${i}`;
+        return (
+          <div key={i}>
+            <input checked={selected === i} type="radio" id={id} onChange={handleAnswer(i)} />
+            <label htmlFor={id}>{option}</label>
+          </div>
+        );
+      })}
+      {step > 1 && <Button clickEvent={handlePrev} buttonStyle="" buttonText="Prev" />}
+      {step < 5 && <Button clickEvent={handleNext} buttonStyle="" buttonText={selected !== null ? 'Next' : 'Skip'} />}
     </div>
   );
 }

--- a/src/views/WizardFormPage.js
+++ b/src/views/WizardFormPage.js
@@ -1,11 +1,94 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import DashboardTopBar from '../components/navigation/DashboardTopBar';
+import WizardFormQA from '../components/wizardForm/WizardFormQA';
+import WizardFormConfirmation from '../components/wizardForm/WizardFormConfirmation';
+import _questions from './wizardFormQuestions.json';
 
 function WizardFormPage() {
+  const [step, setStep] = useState(1);
+  const [questions, setQuestions] = useState(_questions);
+
+  const handleAnswer = questionIx => optionIx => _e => {
+    setQuestions(
+      questions.map((q, ix) =>
+        ix === questionIx
+          ? {
+              ...q,
+              selected: optionIx
+            }
+          : q
+      )
+    );
+  };
+
+  useEffect(() => {
+    // Attempt to read from local storage on componentDidMount
+    // If nothing stored, use default values from above
+    const formState = JSON.parse(localStorage.getItem('wizardForm'));
+
+    if (formState) {
+      setQuestions(formState.questions);
+      setStep(formState.step);
+    }
+  }, []);
+
+  useEffect(() => {
+    console.log({ questions });
+    saveToLocalStorage({ questions, step });
+  }, [questions, step]);
+
+  const saveToLocalStorage = ({ questions, step }) => {
+    localStorage.setItem('wizardForm', JSON.stringify({ questions, step }));
+  };
+  const handleNext = () => {
+    setStep(step + 1);
+  };
+  const handlePrev = () => {
+    setStep(step - 1);
+  };
+  const handleSubmit = e => {
+    e.preventDefault();
+    // This will format the questions array into an object
+    // that matches the shape specified in the GraphQL schema
+    const serialized = questions.reduce(
+      (obj, { key, selected, options }) => ({
+        ...obj,
+        [key]: selected ? options[selected] : null
+      }),
+      {}
+    );
+    // @TODO: On submit, need to commit this to Redux store
+    //        and re-route/display SignUp component
+    console.log(serialized);
+  };
+
   return (
     <div>
       <DashboardTopBar />
       <h1>WizardFormPage</h1>
+      <div style={{ marginTop: '20vh' }}>
+        <form>
+          {step < 5 ? (
+            questions.map(
+              ({ questionContent, options, selected }, i) =>
+                step === i + 1 && (
+                  <WizardFormQA
+                    key={i}
+                    step={step}
+                    questionContent={questionContent}
+                    options={options}
+                    selected={selected}
+                    handleAnswer={handleAnswer(i)}
+                    handleNext={handleNext}
+                    handlePrev={handlePrev}
+                  />
+                )
+            )
+          ) : (
+            <WizardFormConfirmation questions={questions} handleAnswer={handleAnswer} handleSubmit={handleSubmit} />
+          )}
+        </form>
+      </div>
     </div>
   );
 }

--- a/src/views/wizardFormQuestions.json
+++ b/src/views/wizardFormQuestions.json
@@ -1,0 +1,30 @@
+[
+  {
+    "questionContent": "What material are your countertops?",
+    "title": "Countertops",
+    "options": ["Laminate", "Marble/Quartz", "Granite/Concrete", "Formica/Tile"],
+    "key": "countertops",
+    "selected": null
+  },
+  {
+    "questionContent": "What material is your kitchen flooring",
+    "title": "Kitchen flooring type",
+    "options": ["Hardwood", "Engineered/Laminate", "Ceramic Tile", "Porcelain Tile/Concrete"],
+    "key": "flooring",
+    "selected": null
+  },
+  {
+    "questionContent": "How old is your roof?",
+    "title": "Roof age",
+    "options": ["0-4 years", "5-9 years", "10-14 years", "15+"],
+    "key": "roofAge",
+    "selected": null
+  },
+  {
+    "questionContent": "How old is your furnace?",
+    "title": "Furnace age",
+    "options": ["0-4 years", "5-9 years", "10-14 years", "15+"],
+    "key": "furnaceAge",
+    "selected": null
+  }
+]


### PR DESCRIPTION
# Description

This adds the Wizard Form container component as well as the components for displaying the current question and answer and the confirmation page. Form state is stored on and read from `localStorage` so the user can refresh the page halfway through completing and not lose progress.

**Todo:** Need to connect this with the `LandingPage` (before this form) and the `SignUp` form (after completing the form), as part of the same user flow.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
