### PR TITLE
Bugfix: add explicit null-check to avoid zero coercion to false

### DIFF
--- a/src/components/wizardForm/WizardFormConfirmation.js
+++ b/src/components/wizardForm/WizardFormConfirmation.js
@@ -15,7 +15,7 @@ function WizardFormConfirmation({ questions, handleAnswer, handleSubmit }) {
       {questions.map(({ title, options, selected }, qIx) => (
         <Fragment key={qIx}>
           <label htmlFor={title}>{title}</label>
-          <select onChange={handleChange(qIx)} value={selected || NULL} id={title}>
+          <select onChange={handleChange(qIx)} value={selected === null ? NULL : selected} id={title}>
             <option value={NULL}>Not applicable</option>
             {options.map((opt, oIx) => (
               <option key={oIx} value={oIx}>

--- a/src/components/wizardForm/WizardFormConfirmation.js
+++ b/src/components/wizardForm/WizardFormConfirmation.js
@@ -1,6 +1,8 @@
 import React, { Fragment } from 'react';
 import Button from '../../components/buttons/Button';
 
+// This is necessary because we are representing "no selection" as `null`
+// but `null` is not valid as a value for a `select` element.
 const NULL = 'NULL';
 
 function WizardFormConfirmation({ questions, handleAnswer, handleSubmit }) {


### PR DESCRIPTION
# Description

Small bugfix for the select component behavior in the wizard form confirmation page. Also adding comment about the need to use a `NULL` variable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual test: select first option in list of options for select component

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
